### PR TITLE
Dexalot fuji subnet reward manager network upgrade

### DIFF
--- a/chains/432201/upgrade.json
+++ b/chains/432201/upgrade.json
@@ -5,6 +5,14 @@
           "adminAddresses": ["0x42E4BAA2C0B140bE35684824FFf7204159C588B9","0x813738EC93E15dA3c333d834bde68036cFAAb110"],
           "blockTimestamp": 1661266800
         }
+      },
+      {
+        "rewardManagerConfig": {
+          "blockTimestamp": 1672945200,
+          "initialRewardConfig": {
+            "rewardAddress": "0xB2F0b64B6AaD197151d7BcCa515E135C65039E12"
+          }
+        }
       }
     ]
 }


### PR DESCRIPTION
upgrade.json changes related to reward manager precompile network upgrade planned to be activated on 05.01.2023 19:00 GMT