### PR TITLE
Dexalot Subnet reward manager network upgrade

### DIFF
--- a/chains/432204/upgrade.json
+++ b/chains/432204/upgrade.json
@@ -1,0 +1,12 @@
+{
+    "precompileUpgrades": [
+      {
+        "rewardManagerConfig": {
+          "blockTimestamp": 1674496800,
+          "initialRewardConfig": {
+            "rewardAddress": "0xB2F0b64B6AaD197151d7BcCa515E135C65039E12"
+          }
+        }
+      }
+    ]
+}


### PR DESCRIPTION
upgrade.json changes related to reward manager precompile network upgrade planned to be activated on 23.01.2023 18:00 GMT