### PR TITLE
Increase Cap for CRYSTAL token pursuant to the Serendale 2.0 Tokenomics Vote via State Upgrade

### DIFF
--- a/chains/335/upgrade.json
+++ b/chains/335/upgrade.json
@@ -2,9 +2,7 @@
   "precompileUpgrades": [
     {
       "feeManagerConfig": {
-        "adminAddresses": [
-          "0x6D4CFd4e19B30050c8963ebf61F4d3cce5641a79"
-        ],
+        "adminAddresses": ["0x6D4CFd4e19B30050c8963ebf61F4d3cce5641a79"],
         "blockTimestamp": 1661619600
       }
     },
@@ -12,6 +10,19 @@
       "contractDeployerAllowListConfig": {
         "blockTimestamp": 1666368000,
         "disable": true
+      }
+    }
+  ],
+  "stateUpgrades": [
+    {
+      "blockTimestamp": 1678744800,
+      "accounts": {
+        "0xa5c47B4bEb35215fB0CF0Ea6516F9921591c3aCE": {
+          "storage": {
+            "0x0000000000000000000000000000000000000000000000000000000000000007": "0x000000000000000000000000000000000000000000cecb8f27f4200f3a000000",
+            "0x000000000000000000000000000000000000000000000000000000000000000b": "0x00000000000000000000000000000000000000000069E10DE76676D080000000"
+          }
+        }
       }
     }
   ]

--- a/chains/335/upgrade.json
+++ b/chains/335/upgrade.json
@@ -15,7 +15,7 @@
   ],
   "stateUpgrades": [
     {
-      "blockTimestamp": 1678744800,
+      "blockTimestamp": 1678813200,
       "accounts": {
         "0xa5c47B4bEb35215fB0CF0Ea6516F9921591c3aCE": {
           "storage": {


### PR DESCRIPTION
In order to carry out the result of DeFi Kingdom's Governance Vote 17, this State Upgrade will modify two storage slots on the CRYSTAL token contract on DFK Chain Testnet (335), located at address `0xa5c47B4bEb35215fB0CF0Ea6516F9921591c3aCE`. These contract storage slots correspond to two variables, `cap` and `manualMintLimit`. These values will be updated to 250 million and 128 million, respectively, in order to increase the cap of the CRYSTAL token and allow the difference between the new supply cap and the old cap to be distributed via airdrop, as detailed in the governance vote.

[Link to Snapshot Vote](https://vote.defikingdoms.com/#/proposal/0x2a83ec79bf88a5d8170b831b4c941a934e47ca0c569a40bb8d240666978b73e6 )