### PR TITLE
Activate Warp Precompile on DFK Chain Testnet

### DIFF
--- a/chains/335/upgrade.json
+++ b/chains/335/upgrade.json
@@ -11,6 +11,13 @@
         "blockTimestamp": 1666368000,
         "disable": true
       }
+    },
+    {
+      "warpConfig": {
+        "blockTimestamp": 1740004200,
+        "quorumNumerator": 67,
+        "requirePrimaryNetworkSigners": true
+      }
     }
   ],
   "stateUpgrades": [


### PR DESCRIPTION
Modifies the `upgrade.json` file for DFK Chain Testnet (chainId 335) in order to activate the Warp precompile on the network at timestamp `1740004200`.