### PR TITLE
Activate Warp Precompile on DFK Chain

### DIFF
--- a/chains/53935/upgrade.json
+++ b/chains/53935/upgrade.json
@@ -5,6 +5,13 @@
         "adminAddresses": ["0x79A1A35d07044a3d856197756b82319E7F97ba25"],
         "blockTimestamp": 1662134400
       }
+    },
+    {
+      "warpConfig": {
+        "blockTimestamp": 1741068000,
+        "quorumNumerator": 67,
+        "requirePrimaryNetworkSigners": true
+      }
     }
   ],
   "stateUpgrades": [


### PR DESCRIPTION
Modifies the `upgrade.json` file for DFK Chain (chainId 53935) in order to activate the Warp precompile on the network at timestamp `1741068000`.